### PR TITLE
add jitpack repo internally

### DIFF
--- a/gson_plugin/src/main/groovy/com/ke/gson/plugin/GsonPlugin.groovy
+++ b/gson_plugin/src/main/groovy/com/ke/gson/plugin/GsonPlugin.groovy
@@ -12,6 +12,12 @@ class GsonPlugin implements Plugin<Project> {
 
   @Override
   void apply(Project project) {
+    
+    // add jitpack repo
+    project.repositories.maven {
+      url "https://jitpack.io"
+    }
+    
     // add dependencies
     project.dependencies.add("compile",
         "com.github.LianjiaTech:gson-plugin-sdk:1.0.0")


### PR DESCRIPTION
Because `gson-plugin-sdk` was in the jitpack repository, we should be responsible for it.